### PR TITLE
Fix exim.conf primary_hostname regexp to match line

### DIFF
--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -80,7 +80,7 @@ class directadmin::mail(
   file_line { 'exim-set-primary-hostname':
     path  => '/etc/exim.conf',
     line  => "primary_hostname = ${::fqdn}",
-    match => '# primary_hostname',
+    match => '^(# )?primary_hostname =',
     notify  => Service['exim'],
     require => Exec['directadmin-installer'],
   }


### PR DESCRIPTION
The regexp should match the inserted line itself. This fixes: "Error: Validation of File_line[exim-set-primary-hostname] failed: When providing a 'match' parameter, the value must be a regex that matches against the value of your 'line' parameter"

It also prevents file_line appending the line to the bottom of the file which could cause a syntax error.
