### PR TITLE
Fix grepping for existing options in custombuild set

### DIFF
--- a/manifests/custombuild/set.pp
+++ b/manifests/custombuild/set.pp
@@ -8,7 +8,7 @@ define directadmin::custombuild::set($value = '') {
   # It needs to run before the installation so we can pre-set things before it runs.
   exec { "custombuild-set-${title}-${value}":
     command => "/usr/local/directadmin/custombuild/build set ${title} ${value}",
-    unless => "grep /usr/local/directadmin/custombuild/options.conf -e '${title}=${value}'",
+    unless => "grep /usr/local/directadmin/custombuild/options.conf -e '^${title}=${value}'",
     require => Class['directadmin::custombuild'],
     before => Class['directadmin::install'],
   }


### PR DESCRIPTION
Due to missing start of line marker in the grep regexp, the grep command can have false positives.

Example: if options.conf contains `clamav_exit=yes`, the original grep would find `exim=yes` in this line, and therefore passing 'set exim yes' in custombuild options would do nothing as the exec would not run.
