### PR TITLE
Fix file_line regexps in directadmin::config::set

### DIFF
--- a/manifests/config/set.pp
+++ b/manifests/config/set.pp
@@ -6,7 +6,7 @@ define directadmin::config::set($value = '') {
   file_line { "config-set-${title}-${value}":
     path  => '/usr/local/directadmin/conf/directadmin.conf',
     line  => "${title}=${value}",
-    match => "${title}\=",
+    match => "^${title}=",
     require => Class['directadmin::install'],
     notify  => Service['directadmin'],
   }
@@ -18,7 +18,7 @@ define directadmin::config::set($value = '') {
     file_line { "config-set-admin-user-${title}-${value}":
       path  => '/usr/local/directadmin/data/users/admin/user.conf',
       line  => "${title}=${value}",
-      match => "${title}\=",
+      match => "^${title}=",
       require => Class['directadmin::install'],
     }
 
@@ -26,7 +26,7 @@ define directadmin::config::set($value = '') {
     file_line { "config-set-admin-reseller-${title}-${value}":
       path  => '/usr/local/directadmin/data/users/admin/reseller.conf',
       line  => "${title}=${value}",
-      match => "${title}\=",
+      match => "^${title}=",
       require => Class['directadmin::install'],
     }
   }


### PR DESCRIPTION
Add start of string marker to prevent conflicts between different variables.

Resolve the following Puppet warnings:

```
Warning: Unrecognised escape sequence '\=' in file manifests/config/set.pp at line 9
Warning: Unrecognised escape sequence '\=' in file manifests/config/set.pp at line 21
Warning: Unrecognised escape sequence '\=' in file manifests/config/set.pp at line 29
```
