### PR TITLE
Add paths to exec resources

### DIFF
--- a/manifests/custombuild.pp
+++ b/manifests/custombuild.pp
@@ -12,5 +12,6 @@ class directadmin::custombuild {
     command => "rm -rf custombuild* && wget --no-check-certificate -O custombuild.tar.gz ${custombuild_installer} && tar xvzf custombuild.tar.gz",
     creates => '/usr/local/directadmin/custombuild/options.conf',
     require => File['/usr/local/directadmin'],
+    path    => '/bin:/usr/bin',
   }
 }

--- a/manifests/custombuild/set.pp
+++ b/manifests/custombuild/set.pp
@@ -11,5 +11,6 @@ define directadmin::custombuild::set($value = '') {
     unless => "grep /usr/local/directadmin/custombuild/options.conf -e '${title}=${value}'",
     require => Class['directadmin::custombuild'],
     before => Class['directadmin::install'],
+    path => '/bin:/usr/bin',
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,6 +63,7 @@ class directadmin::install inherits directadmin {
     command => 'echo 1 > /root/.preinstall',
     creates => '/root/.preinstall',
     before  => Exec['directadmin-installer'],
+    path    => '/bin:/usr/bin',
   }
 
   # Exec: set up the installation files
@@ -70,14 +71,16 @@ class directadmin::install inherits directadmin {
     cwd     => '/root',
     command => "wget -O setup.sh --no-check-certificate ${directadmin_installer} && chmod +x /root/setup.sh",
     creates => '/root/setup.sh',
+    path    => '/bin:/usr/bin',
   }
 
-  # Exec: install DirectAdmin 
+  # Exec: install DirectAdmin
   exec { 'directadmin-installer':
     cwd     => '/root',
     command => "echo 2.0 > /root/.custombuild && /root/setup.sh ${directadmin::clientid} ${directadmin::licenseid} ${::fqdn} ${directadmin_interface}",
     require => [ Exec['directadmin-download-installer'], Class['directadmin::custombuild'], ],
     creates => '/usr/local/directadmin/conf/directadmin.conf',
     timeout => 0,
+    path    => '/sbin:/usr/sbin:/bin:/usr/bin',
   }
 }

--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -12,7 +12,7 @@ class directadmin::mail(
     group   => mail,
     mode    => '0644',
 
-    # maximum e-mails per day, it needs quotes to ensure it gets 
+    # maximum e-mails per day, it needs quotes to ensure it gets
     # read correctly, Hiera will set as an integer for example
     content => "${mail_limit}",
 
@@ -65,6 +65,7 @@ class directadmin::mail(
       command => 'wget -O /root/imap_php.sh files.directadmin.com/services/all/imap_php.sh && chmod +x /root/imap_php.sh',
       creates => '/root/imap_php.sh',
       require => Exec['directadmin-installer'],
+      path    => '/bin:/usr/bin',
     } ->
     exec { 'directadmin-install-php-imap':
       cwd     => '/root',
@@ -72,6 +73,7 @@ class directadmin::mail(
       unless  => 'php -i | grep -i c-client | wc -l | grep -c 1',
       require => Exec['directadmin-installer'],
       timeout => 0,
+      path    => '/bin:/usr/bin',
     }
   }
 


### PR DESCRIPTION
Currently, the exec resources in the manifests assume that paths have globally been set for all Exec resources. Not all users may have this in their `site.pp`. Ensure that paths are added.

**Note:** These paths should be pretty universal as far as I know, but this is only tested on Ubuntu 14.04.
