### PR TITLE
Fix SpamAssassin package install on Ubuntu

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,7 +44,7 @@ class directadmin::install inherits directadmin {
   }
 
   # The following will install all required packages for SpamAssassin on Debian servers.
-  if $::operatingsystem == 'Debian' {
+  if $::osfamily == 'Debian' {
     $directadmin_packages = [
         'libarchive-any-perl', 'libhtml-parser-perl', 'libnet-dns-perl', 'libnetaddr-ip-perl',
         'libhttp-date-perl',


### PR DESCRIPTION
Since Ubuntu is a Debian derivative, just check on `$::osfamily` instead.
