### PR TITLE
On Debian, crypt the admin password

### DIFF
--- a/manifests/resources.pp
+++ b/manifests/resources.pp
@@ -2,7 +2,15 @@
 class directadmin::resources {
   # Create additional admin users and manage the primary one
   if $directadmin::admin_password != '' {
-    user { 'admin': password => $directadmin::admin_password, }
+    if $::osfamily == 'Debian' {
+        # usermod expects the password parameter to be crypted
+        include stdlib
+        $plaintext_password = $directadmin::admin_password
+        $salt = fqdn_rand(4294967295, 'directadmin_admin_password')
+        user { 'admin': password => pw_hash($plaintext_password, 'SHA-512', $salt), }
+      } else {
+        user { 'admin': password => $directadmin::admin_password, }
+      }
   }
   $directadmin_admins = hiera('directadmin::admins', {})
   create_resources(directadmin_admin, $directadmin_admins)


### PR DESCRIPTION
Setting the admin password fails on Debian.
Debian wants a crypted password hash to be passed to usermod.
Use puppetlabs stdlib's `pw_hash` function to generate a hash.
This function also requires a salt, use `fqdn_rand` to generate one from the hostname.

A completely random salt would be even better, but it would make the manifest more complex to generate one without creating new strings on every Puppet run. DirectAdmin stores many details in plaintext already, so I consider it low priority.
