### PR TITLE
Add support for running DirectAdmin behind a NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ and eth0 on other systems. You can override this setting or not set it at all.
 If you set `auto_update` to true it will attempt to update all packages that are
 installed through Custombuild 2.0.
 
+Set `lan` to true when using [DirectAdmin behind a NAT](http://www.directadmin.com/lan.shtml).
+
 ```
 class { 'directadmin':
 	clientid       => '1000',
@@ -30,6 +32,7 @@ class { 'directadmin':
 	interface      => 'eth0',
 	auto_update    => true,
 	admin_password => 's0m3p4ssw0rd',
+	lan            => false,
 }
 ```
 
@@ -54,6 +57,9 @@ directadmin::config::options:
     value: 30
   enable_ssl_sni:
     value: 1
+  #If you run DirectAdmin behind a NAT, set lan_ip option:
+  #lan_ip:
+  #  value: 192.168.0.2
 ```
 
 Changing a DirectAdmin configuration option will automatically trigger a reload of

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class directadmin(
   $interface = 'none',
   $auto_update = false,
   $admin_password = '',
+  $lan = false,
 ) {
   # Run some sanity checks
   if !is_numeric($directadmin::clientid) { fail("The client ID ${directadmin::clientid} is not a number.") }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,6 +57,17 @@ class directadmin::install inherits directadmin {
     before  => Exec['directadmin-download-installer'],
   }
 
+  # Using DirectAdmin on a server behind NAT (example: 192.168.0.x)? Touch /root/.lan.
+  # When this file contains '1', setup.sh will skip --bind-address in wget.
+  # For more information about running DirectAdmin behind NAT: http://www.directadmin.com/lan.shtml
+  if $directadmin::lan {
+    file { '/root/.lan':
+      ensure  => file,
+      content => '1',
+      before  => Exec['directadmin-installer'],
+    }
+  }
+
   # Exec: make sure the required packages are installed automatically. This provides support for all operating systems.
   exec { 'directadmin-set-pre-install':
     cwd     => '/root',


### PR DESCRIPTION
This adds support for DirectAdmin "LAN" mode by a `lan` parameter.

DirectAdmin has unofficial support for [running behind a NAT](http://www.directadmin.com/lan.shtml). This requires writing a file `/root/.lan` before install. This file is checked by DirectAdmin setup.

Running behind a NAT also requires a DirectAdmin config option and some additional config in the panel. Add examples and link to DirectAdmin help page to the README.
